### PR TITLE
typos in failing tests after 1e6883c

### DIFF
--- a/tests/aave/test_aave_withdraw.py
+++ b/tests/aave/test_aave_withdraw.py
@@ -8,11 +8,11 @@ def deposited(aave, USDC):
 def test_withdraw(safe, aave, USDC, aUSDC):
     bal_before_usdc = USDC.balanceOf(safe)
     bal_before_ausdc = aUSDC.balanceOf(safe)
-    
+
     to_withdraw = 1000 * 10**USDC.decimals()
 
     aave.withdraw(USDC, to_withdraw)
-    
+
     # aave will sometimes give you slightly more/less than what you asked for, so test >=
     assert USDC.balanceOf(safe) >= bal_before_usdc + to_withdraw
     assert aUSDC.balanceOf(safe) >= bal_before_ausdc - to_withdraw
@@ -24,5 +24,5 @@ def test_withdraw_all(safe, aave, USDC, aUSDC):
 
     aave.withdraw_all(USDC)
 
-    assert USDC.balanceOf(safe) < bal_before_usdc + bal_before_ausdc
+    assert USDC.balanceOf(safe) >= bal_before_usdc + bal_before_ausdc
     assert aUSDC.balanceOf(safe) == 0

--- a/tests/compound/test_compound_withdraw.py
+++ b/tests/compound/test_compound_withdraw.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope='function', autouse=True)
 def deposited(compound, USDC):
-    to_deposit_usdc = 10_000 * 10**USDC.decimals()
+    to_deposit_usdc = 100_000 * 10**USDC.decimals()
     compound.deposit(USDC, to_deposit_usdc)
 
     to_deposit_eth = 10**18
@@ -11,7 +11,7 @@ def deposited(compound, USDC):
 
 
 def test_withdraw(safe, compound, USDC, cUSDC):
-    
+
     before_bal_usdc = USDC.balanceOf(safe)
     before_bal_cUSDC = cUSDC.balanceOf(safe)
     to_withdraw = 100_000 * 10**USDC.decimals()
@@ -24,7 +24,7 @@ def test_withdraw(safe, compound, USDC, cUSDC):
 
 
 def test_withdraw_eth(safe, compound, cETH):
-    
+
     before_bal_eth= safe.account.balance()
     before_bal_ceth = cETH.balanceOf(safe)
 


### PR DESCRIPTION
just some minor things that broke due to 1e6883c. @jalbrekt85 be sure to run full suite again before PRing! i guess i should have done the same before merging...

i will look into setting up a github action for that 👀